### PR TITLE
fix(navbar): use archive_dir instead of 'archives/'

### DIFF
--- a/layout/_partial/index-nav.ejs
+++ b/layout/_partial/index-nav.ejs
@@ -2,8 +2,10 @@
     <% if (theme.nav.home.use === true) { %>
         <a href="<%= url_for('/') %>" class="navbar-link"><%= __('home') %></a>
     <% } %>
-    <% if (theme.nav.archives.use === true) { %>
-        <a href="<%= url_for('archives/') %>" class="navbar-link"><%= __('archive') %></a>
+    <% if (theme.nav.archives.use === true) {
+        var archiveDir = config.archive_dir;
+        if (archiveDir[archiveDir.length - 1] !== '/') archiveDir += '/'; %>
+        <a href="<%= url_for(archiveDir) %>" class="navbar-link"><%= __('archive') %></a>
     <% } %>
     <% if (theme.nav.search.use === true) { %>
         <a href="<%= theme.nav.search.link %>" class="navbar-link"><%= __('search.main') %></a>


### PR DESCRIPTION
## Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines.
- [ ] Tests for the changes have been added (for bug fixes / new features).
- [ ] Docs have been added / updated (for bug fixes / new features).

## What kind of change does this PR introduce? (check with "x")

- [x] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change? (check one with "x")

- [ ] Yes
- [x] No

____

## Description
When user change `archive_dir`, the theme still use `archives/` as `archive_dir`. This commit fix this issue by using archive_dir in config.

____

## Verification steps

